### PR TITLE
Add max height to emoji drop down

### DIFF
--- a/theme/charactergrid.css
+++ b/theme/charactergrid.css
@@ -9,3 +9,8 @@
 		grid-template-columns: repeat( 10, 1fr );
 	}
 }
+
+.ck.ck-character-grid {
+	overflow: auto;
+	max-height: 300px;
+}


### PR DESCRIPTION
This makes the popover a bit nicer as it does not overflow the screen, and looks more like other emoji popups (in slack etc.)

![Screen Shot 2021-03-12 at 11 05 52 AM](https://user-images.githubusercontent.com/8773071/110862418-5569f200-8324-11eb-8291-a5cdee6bf302.png)
